### PR TITLE
スキル一覧ページ作成

### DIFF
--- a/frontend/src/data/skills.ts
+++ b/frontend/src/data/skills.ts
@@ -3,55 +3,142 @@ export const skills = [
     id: 1,
     name: 'Ruby',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/ruby/ruby-original.svg',
+    abilities: [
+      {
+        id: 1,
+        content:
+          'オブジェクト指向プログラミング言語で、簡潔で読みやすいコードを書くことができます。主にWebアプリケーションやスクリプト作成に使用されます。',
+      },
+      {
+        id: 2,
+        content:
+          'オブジェクト指向プログラミング言語で、簡潔で読みやすいコードを書くことができます。主にWebアプリケーションやスクリプト作成に使用されます。',
+      },
+      {
+        id: 3,
+        content:
+          'オブジェクト指向プログラミング言語で、簡潔で読みやすいコードを書くことができます。主にWebアプリケーションやスクリプト作成に使用されます。',
+      },
+    ],
   },
   {
     id: 2,
     name: 'Rails',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/rails/rails-plain.svg',
+    abilities: [
+      {
+        id: 2,
+        content:
+          'Rubyで作られたWebアプリケーションフレームワークで、CRUD機能や認証機能を効率的に開発できます。',
+      },
+    ],
   },
   {
     id: 3,
     name: 'PostgreSQL',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/postgresql/postgresql-original.svg',
+    abilities: [
+      {
+        id: 3,
+        content:
+          '強力でスケーラブルなリレーショナルデータベースで、データ管理や分析を行うことができます。',
+      },
+    ],
   },
   {
     id: 4,
     name: 'React',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/react/react-original.svg',
+    abilities: [
+      {
+        id: 4,
+        content:
+          'コンポーネントベースのライブラリで、動的でインタラクティブなWebアプリケーションを構築するために使用します。',
+      },
+    ],
   },
   {
     id: 5,
     name: 'Next.js',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/nextjs/nextjs-original.svg',
+    abilities: [
+      {
+        id: 5,
+        content:
+          'Reactのフレームワークで、サーバーサイドレンダリングや静的サイト生成をサポートし、高速でSEOに強いWebアプリケーションを開発できます。',
+      },
+    ],
   },
   {
     id: 6,
     name: 'TypeScript',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg',
+    abilities: [
+      {
+        id: 6,
+        content:
+          'JavaScriptのスーパーセットで、型定義を追加することでコードの保守性と開発効率を向上させます。',
+      },
+    ],
   },
   {
     id: 7,
     name: 'Github',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/github/github-original.svg',
+    abilities: [
+      {
+        id: 7,
+        content:
+          'コードのバージョン管理や共同開発が可能なプラットフォームで、リポジトリを公開・共有できます。',
+      },
+    ],
   },
   {
     id: 8,
     name: 'Github Actions',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/githubactions/githubactions-original.svg',
+    abilities: [
+      {
+        id: 8,
+        content:
+          'CI/CD（継続的インテグレーション/継続的デリバリー）を実現するためのツールで、自動テストやデプロイを設定できます。',
+      },
+    ],
   },
   {
     id: 9,
     name: 'Docker',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/docker/docker-original.svg',
+    abilities: [
+      {
+        id: 9,
+        content:
+          'アプリケーションをコンテナ化するツールで、環境の統一やデプロイの効率化を図ることができます。',
+      },
+    ],
   },
   {
     id: 10,
     name: 'AWS',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/amazonwebservices/amazonwebservices-original-wordmark.svg',
+    abilities: [
+      {
+        id: 10,
+        content:
+          'クラウドサービスプロバイダーで、インフラ構築、ストレージ、データベース、機械学習など幅広い機能を提供します。',
+      },
+    ],
   },
   {
     id: 11,
     name: 'Terraform',
     logo: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/terraform/terraform-original.svg',
+    abilities: [
+      {
+        id: 11,
+        content:
+          'インフラストラクチャをコード化するツールで、インフラの管理とプロビジョニングを効率化します。',
+      },
+    ],
   },
 ]

--- a/frontend/src/features/skill/components/SkillAccordion.tsx
+++ b/frontend/src/features/skill/components/SkillAccordion.tsx
@@ -1,13 +1,13 @@
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Typography,
 } from '@mui/material'
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
-import { Skill } from '@/types/skill'
 import Image from 'next/image'
 import { FlexLayout } from '@/components/layouts/common/FlexContainer'
+import { Skill } from '@/types/skill'
 
 type SkillAccordionProps = {
   skills: Skill[]

--- a/frontend/src/features/skill/components/SkillAccordion.tsx
+++ b/frontend/src/features/skill/components/SkillAccordion.tsx
@@ -1,0 +1,43 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Typography,
+} from '@mui/material'
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
+import { Skill } from '@/types/skill'
+import Image from 'next/image'
+import { FlexLayout } from '@/components/layouts/common/FlexContainer'
+
+type SkillAccordionProps = {
+  skills: Skill[]
+}
+
+export const SkillAccordion = ({ skills }: SkillAccordionProps) => {
+  return (
+    <>
+      {skills.map((skill) => (
+        <Accordion key={skill.id}>
+          <AccordionSummary
+            sx={{ display: 'flex', alignItems: 'center' }}
+            expandIcon={<ArrowDropDownIcon />}
+            aria-controls={`panel-${skill.id}-content`}
+            id={`panel-${skill.id}-header`}
+          >
+            <FlexLayout>
+              <Image src={skill.logo} alt={skill.name} width={30} height={30} />
+              <Typography component="span" sx={{ marginLeft: 2 }}>
+                {skill.name}
+              </Typography>
+            </FlexLayout>
+          </AccordionSummary>
+          {skill.abilities.map((ability) => (
+            <AccordionDetails key={ability.id}>
+              <Typography>{ability.content}</Typography>
+            </AccordionDetails>
+          ))}
+        </Accordion>
+      ))}
+    </>
+  )
+}

--- a/frontend/src/pages/skills/index.tsx
+++ b/frontend/src/pages/skills/index.tsx
@@ -1,8 +1,8 @@
+import { Box, Container, Typography } from '@mui/material'
 import { TextAlignLayout } from '@/components/layouts/common/TextAlignContainer'
 import { skills } from '@/data/skills'
 import { SkillAccordion } from '@/features/skill/components/SkillAccordion'
 import { Skill } from '@/types/skill'
-import { Box, Container, Typography } from '@mui/material'
 
 type SkillIndexProps = {
   skills: Skill[]

--- a/frontend/src/pages/skills/index.tsx
+++ b/frontend/src/pages/skills/index.tsx
@@ -1,0 +1,34 @@
+import { TextAlignLayout } from '@/components/layouts/common/TextAlignContainer'
+import { skills } from '@/data/skills'
+import { SkillAccordion } from '@/features/skill/components/SkillAccordion'
+import { Skill } from '@/types/skill'
+import { Box, Container, Typography } from '@mui/material'
+
+type SkillIndexProps = {
+  skills: Skill[]
+}
+
+const SkillIndex = ({ skills }: SkillIndexProps) => {
+  return (
+    <>
+      <Container maxWidth="sm" sx={{ paddingY: 10 }}>
+        <TextAlignLayout align="center">
+          <Typography variant="h3">Skill</Typography>
+        </TextAlignLayout>
+        <Box sx={{ marginTop: 4 }}>
+          <SkillAccordion skills={skills} />
+        </Box>
+      </Container>
+    </>
+  )
+}
+
+export const getStaticProps = async () => {
+  return {
+    props: {
+      skills,
+    },
+  }
+}
+
+export default SkillIndex

--- a/frontend/src/types/ability.ts
+++ b/frontend/src/types/ability.ts
@@ -1,0 +1,4 @@
+export type Ability = {
+  id: number
+  content: string
+}

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -1,5 +1,8 @@
+import { Ability } from './ability'
+
 export type Skill = {
   id: number
   name: string
   logo: string
+  abilities: Ability[]
 }


### PR DESCRIPTION
## 概要

スキル一覧ページ作成

## やったこと

- Abilityの型作成
- skillsのデータにabilitiesを追加
- スキル一覧を表示するためのアコーディオンコンポーネント作成
- スキル一覧ページコンポーネント作成

## 動作確認

https://keita-portfolio-gold.vercel.app/skills

## 懸念点

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added detailed skill descriptions (abilities) in Japanese for each skill
	- Introduced a new Skills page with an interactive accordion-style skill display
	- Enhanced skill data structure to include more contextual information

- **Documentation**
	- Updated type definitions to support new skill abilities feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->