### PR TITLE
デプロイ時のリクエストを許可する設定を開発環境に移動

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -40,6 +40,5 @@ module Myapp
 
     config.active_record.default_timezone = :local
 
-    config.hosts << "backend"
   end
 end

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -61,4 +61,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.hosts << "backend"
 end


### PR DESCRIPTION
## 概要

デプロイ時のリクエストを許可する設定を開発環境に移動

## やったこと

設定をapplication.rbからdevelopment.rbに移動

## 動作確認

https://keita-portfolio-gold.vercel.app/about

https://keita-portfolio.onrender.com

## 懸念点

## その他
