### PR TITLE
スキル一覧表示API作成

### DIFF
--- a/backend/app/controllers/api/profile_controller.rb
+++ b/backend/app/controllers/api/profile_controller.rb
@@ -1,10 +1,10 @@
 class Api::ProfileController < ApplicationController
   def show
     user = User.find_by(email: "test@example.com")
-    @profile = user.profile
+    profile = user.profile
 
-    if @profile
-      render json: @profile
+    if profile
+      render json: profile
     else
       render json: { error: "Profile not found" }, status: :not_found
     end

--- a/backend/app/controllers/api/skills_controller.rb
+++ b/backend/app/controllers/api/skills_controller.rb
@@ -1,0 +1,24 @@
+class Api::SkillsController < ApplicationController
+  def index
+    user = find_user
+    return render json: { error: "User not found" }, status: :not_found unless user
+
+    skills = find_skills(user)
+
+    if skills.present?
+      render json: skills.as_json(include: :abilities)
+    else
+      render json: { error: "Skill not found" }, status: :not_found
+    end
+  end
+
+  private
+
+    def find_user
+      User.find_by(email: "test@example.com")
+    end
+
+    def find_skills(user)
+      user.skills.includes(:abilities)
+    end
+end

--- a/backend/app/models/ability.rb
+++ b/backend/app/models/ability.rb
@@ -1,0 +1,3 @@
+class Ability < ApplicationRecord
+  belongs_to :skill
+end

--- a/backend/app/models/skill.rb
+++ b/backend/app/models/skill.rb
@@ -1,0 +1,4 @@
+class Skill < ApplicationRecord
+  belongs_to :user
+  has_many :abilities, dependent: :destroy
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   has_one :profile, dependent: :destroy
+  has_many :skills, dependent: :destroy
+
   has_secure_password
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   namespace :api do
     get "health_check", to: "health_check#index"
     get "profile", to: "profile#show"
+    get "skills", to: "skills#index"
   end
 end

--- a/backend/db/migrate/20250110131142_create_skills.rb
+++ b/backend/db/migrate/20250110131142_create_skills.rb
@@ -1,0 +1,11 @@
+class CreateSkills < ActiveRecord::Migration[7.0]
+  def change
+    create_table :skills do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :logo_url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20250110131144_create_abilities.rb
+++ b/backend/db/migrate/20250110131144_create_abilities.rb
@@ -1,0 +1,10 @@
+class CreateAbilities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :abilities do |t|
+      t.text :content, null: false
+      t.references :skill, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_06_095713) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_10_131144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "abilities", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "skill_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["skill_id"], name: "index_abilities_on_skill_id"
+  end
 
   create_table "profiles", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -32,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_06_095713) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "skills", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "logo_url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_skills_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
@@ -39,5 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_06_095713) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "abilities", "skills"
   add_foreign_key "profiles", "users"
+  add_foreign_key "skills", "users"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -18,3 +18,152 @@ Profile.create!(
   x_url: "https://x.com/k1e8i9t9a",
   qiita_url: "https://qiita.com/keita1899",
 )
+
+skills_with_abilities = [
+  {
+    name: "Ruby",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/ruby/ruby-original.svg",
+    abilities: [
+      "基本的な文法やオブジェクト指向を理解している",
+      "Rubocop で静的解析を導入できる",
+      "RSpec で基本的なテストを書ける",
+    ],
+  },
+  {
+    name: "Rails",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/rails/rails-plain.svg",
+    abilities: [
+      "CRUD や Web アプリの主要な機能を実装できる",
+      "Devise で認証機能を実装できる",
+      "gem を使わずに実装する認証機能の仕組みを理解している",
+      "API を作れる",
+    ],
+  },
+  {
+    name: "SQL",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/azuresqldatabase/azuresqldatabase-original.svg",
+    abilities: [
+      "基本的な CRUD 操作ができる",
+      "基本的な検索ができる",
+      "正規化ができる",
+      "インデックスや制約、データ型について理解している",
+      "トランザクションをざっくり理解している",
+    ],
+  },
+  {
+    name: "HTML",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/html5/html5-original.svg",
+    abilities: [
+      "基本的なタグを理解している",
+    ],
+  },
+  {
+    name: "CSS",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/css3/css3-original.svg",
+    abilities: [
+      "基本的なスタイルを理解している",
+      "FlexBox や Grid を使ってレスポンシブデザインを作れる",
+      "BEM のような CSS 設計をざっくり理解している",
+      "Sass を使える",
+    ],
+  },
+  {
+    name: "JavaScript",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/javascript/javascript-original.svg",
+    abilities: [
+      "基本的な文法を理解している",
+      "オブジェクトについて理解している（プロトタイプとクラス）",
+      "関数の違いを理解している",
+      "this の挙動について理解している",
+      "非同期処理についてざっくり理解している",
+      "基本的な DOM 操作ができる",
+      "ES6 の記法を理解して、React で使える",
+      "npm、yarn のパッケージ管理ツールを扱える",
+      "基本的な Webpack の操作ができる",
+      "ESLint、Prettier を使って静的解析とコードの整形ができる",
+    ],
+  },
+  {
+    name: "TypeScript",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+    abilities: [
+      "基本的な型について理解している",
+      "型エイリアスやインターフェースを使える",
+      "ジェネリクスを使える",
+    ],
+  },
+  {
+    name: "React",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/react/react-original.svg",
+    abilities: [
+      "React の概念、メリットを理解している（仮想 DOM、宣言的 UI、コンポーネント指向、単方向データフロー）",
+      "基本を理解している（コンポーネント、JSX、state、props、再レンダリング）",
+      "クラスコンポーネントと関数コンポーネントの違いについて理解している",
+      "基本的な Hooks の使い方を理解している（useState、useEffect、useReducer、useContext 等）",
+      "React Router でルーティングを実装できる",
+      "MaterialUI のようなコンポーネントライブラリや、TailwindCSS のような CSS フレームワークでスタイルを作れる",
+    ],
+  },
+  {
+    name: "Next.js",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/nextjs/nextjs-original.svg",
+    abilities: [
+      "レンダリングの違いを理解している",
+      "ルーティングの仕組みを理解している",
+      "環境変数を扱える",
+    ],
+  },
+  {
+    name: "Github",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/github/github-original.svg",
+    abilities: [
+      "コミットしてローカルに保存できる",
+      "リモートリポジトリにプッシュして保存できる",
+      "プルリクエストを作れる",
+      "Github Flow でブランチを管理できる",
+    ],
+  },
+  {
+    name: "Github Actions",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/githubactions/githubactions-original.svg",
+    abilities: [
+      "ワークフロー、ジョブ、ステップ等の基本を理解している",
+      "Rails や React の CI を構築できる",
+    ],
+  },
+  {
+    name: "Linux",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/linux/linux-original.svg",
+    abilities: [
+      "基本的なコマンドを使える",
+      "カーネルやシェルの仕組みを理解している",
+      "基本的なディレクトリについて理解している",
+      "vim の基本的な操作ができる",
+      "yum や apt を使ったパッケージの操作ができる",
+      "権限について理解している",
+    ],
+  },
+  {
+    name: "Docker",
+    logo_url: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/docker/docker-original.svg",
+    abilities: [
+      "基本的なコマンドを使える",
+      "Dockerfile、docker-compose.yml の基本的な命令の意味を理解している",
+      "イメージからコンテナを作成し、操作できる",
+      "Docker Compose を使える",
+      "Rails や React の開発環境を構築できる",
+    ],
+  },
+]
+
+skills_with_abilities.each do |skill_data|
+  skill = Skill.create!(
+    user_id: user.id,
+    name: skill_data[:name],
+    logo_url: skill_data[:logo_url],
+  )
+
+  skill_data[:abilities].each do |ability_content|
+    Ability.create!(skill_id: skill.id, content: ability_content)
+  end
+end

--- a/backend/spec/factories/abilities.rb
+++ b/backend/spec/factories/abilities.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ability do
+    skill
+    content { "基本的な文法やオブジェクト指向を理解している" }
+  end
+end

--- a/backend/spec/factories/skills.rb
+++ b/backend/spec/factories/skills.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :skill do
+    user
+    name { "Ruby" }
+    logo_url { "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/ruby/ruby-original.svg" }
+  end
+end

--- a/backend/spec/requests/api/skills_spec.rb
+++ b/backend/spec/requests/api/skills_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Api::Skills", type: :request do
+  let!(:user) { create(:user, email: "test@example.com", password: "password") }
+  let!(:skills) { create_list(:skill, 5, user: user) }
+  let!(:abilities) do
+    skills.each do |skill|
+      create_list(:ability, 3, skill: skill)
+    end
+  end
+
+  describe "GET /index" do
+    context "when skills exist" do
+      it "returns a success response with skills" do
+        get "/api/skills"
+
+        expect(response).to have_http_status(:success)
+        json = JSON.parse(response.body)
+
+        expect(json.length).to eq(5)
+
+        expect(json[0]["abilities"]).to be_present
+      end
+    end
+
+    context "when skills doesn't exist" do
+      before { user.skills.destroy_all }
+
+      it "returns a not_found response with skill not found error" do
+        get "/api/skills"
+        expect(response).to have_http_status(:not_found)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to eq("Skill not found")
+      end
+    end
+  end
+end

--- a/frontend/src/features/home/components/SkillItem.tsx
+++ b/frontend/src/features/home/components/SkillItem.tsx
@@ -17,7 +17,7 @@ export const SkillItem = ({ skill }: SkillItemProps) => {
           justifyContent: 'center',
         }}
       >
-        <Image src={skill.logo} alt="" width={64} height={64} />
+        <Image src={skill.logoUrl} alt="" width={64} height={64} />
         <Typography variant="body2" sx={{ textAlign: 'center' }}>
           {skill.name}
         </Typography>

--- a/frontend/src/features/skill/components/SkillAccordion.tsx
+++ b/frontend/src/features/skill/components/SkillAccordion.tsx
@@ -25,7 +25,12 @@ export const SkillAccordion = ({ skills }: SkillAccordionProps) => {
             id={`panel-${skill.id}-header`}
           >
             <FlexLayout alignItems="center">
-              <Image src={skill.logo} alt={skill.name} width={30} height={30} />
+              <Image
+                src={skill.logoUrl}
+                alt={skill.name}
+                width={30}
+                height={30}
+              />
               <Typography component="span" sx={{ marginLeft: 2 }}>
                 {skill.name}
               </Typography>

--- a/frontend/src/pages/skills/index.tsx
+++ b/frontend/src/pages/skills/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Container } from '@mui/material'
+import axios from 'axios'
+import camelcaseKeys from 'camelcase-keys'
 import { PageTitle } from '@/components/utility/PageTitle'
-import { skills } from '@/data/skills'
 import { SkillAccordion } from '@/features/skill/components/SkillAccordion'
 import { Skill } from '@/types/skill'
 
@@ -10,22 +11,31 @@ type SkillIndexProps = {
 
 const SkillIndex = ({ skills }: SkillIndexProps) => {
   return (
-    <>
-      <Container maxWidth="sm" sx={{ paddingY: 10 }}>
-        <PageTitle title="Skill" />
-        <Box sx={{ marginTop: 4 }}>
-          <SkillAccordion skills={skills} />
-        </Box>
-      </Container>
-    </>
+    <Container maxWidth="sm" sx={{ paddingY: 10 }}>
+      <PageTitle title="Skill" />
+      <Box sx={{ marginTop: 4 }}>
+        <SkillAccordion skills={skills} />
+      </Box>
+    </Container>
   )
 }
 
 export const getStaticProps = async () => {
-  return {
-    props: {
-      skills,
-    },
+  try {
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'https://backend:3000'
+    const skillsRes = await axios.get(`${backendUrl}/api/skills`)
+    const skills = camelcaseKeys(skillsRes.data) as Skill[]
+
+    return {
+      props: {
+        skills,
+      },
+    }
+  } catch (error) {
+    console.error('Failed to fetch skills:', error)
+    return {
+      notFound: true,
+    }
   }
 }
 

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -3,6 +3,6 @@ import { Ability } from './ability'
 export type Skill = {
   id: number
   name: string
-  logo: string
+  logoUrl: string
   abilities: Ability[]
 }


### PR DESCRIPTION
## 概要

スキル一覧表示API作成

## やったこと

- モデルのリレーション作成
- スキル一覧のseed作成
- スキル一覧表示のAPI作成
- Skillの型のプロパティ名を修正
- スキル一覧ページでAPIからデータを取得する
- スキル一覧のリクエストスペック作成

## 動作確認

https://keita-portfolio-gold.vercel.app/skills

API
https://keita-portfolio.onrender.com/api/skills

## 懸念点

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new Skills API endpoint to retrieve user skills and abilities
	- Implemented skills and abilities data models in the backend
	- Created a dynamic skills page that fetches skills data from the backend API

- **Bug Fixes**
	- Updated frontend type definitions and components to match backend changes

- **Refactor**
	- Restructured skills data management across backend and frontend
	- Updated database schema to support skills and abilities relationships

- **Chores**
	- Added database migrations for skills and abilities tables
	- Created test factories and request specs for skills functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->