### PR TITLE
ポートフォリオ詳細機能作成

### DIFF
--- a/backend/app/controllers/api/portfolios_controller.rb
+++ b/backend/app/controllers/api/portfolios_controller.rb
@@ -15,4 +15,19 @@ class Api::PortfoliosController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render json: { error: "User not found" }, status: :not_found
   end
+
+  def show
+    user = find_user
+    portfolio = user.portfolios.includes(:features, :pages, :images, :tech_stacks, :tags).find(params[:id])
+
+    render json: portfolio, include: {
+      features: { only: [:id, :name] },
+      pages: { only: [:id, :name] },
+      images: { only: [:id, :url] },
+      tech_stacks: { only: [:id, :technology, :version] },
+      tags: { only: [:id, :name] },
+    }
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Portfolio not found" }, status: :not_found
+  end
 end

--- a/backend/app/controllers/api/portfolios_controller.rb
+++ b/backend/app/controllers/api/portfolios_controller.rb
@@ -7,8 +7,8 @@ class Api::PortfoliosController < ApplicationController
     portfolios = @user.portfolios.includes(:features, :pages, :images, :tech_stacks, :tags)
 
     render json: portfolios, include: portfolio_includes
-    rescue ActiveRecord::RecordNotFound
-      render json: { error: "User not found" }, status: :not_found
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "User not found" }, status: :not_found
   end
 
   def show
@@ -19,17 +19,16 @@ class Api::PortfoliosController < ApplicationController
     else
       render json: portfolio, include: portfolio_includes
     end
-    
-    rescue ActiveRecord::RecordNotFound
-      render json: { error: "User not found" }, status: :not_found
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "User not found" }, status: :not_found
   end
 
   private
 
     def set_user
       @user = find_user
-      rescue ActiveRecord::RecordNotFound
-        render json: { error: "User not found" }, status: :not_found
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "User not found" }, status: :not_found
     end
 
     def portfolio_includes
@@ -38,7 +37,7 @@ class Api::PortfoliosController < ApplicationController
         pages: { only: [:id, :name] },
         images: { only: [:id, :url] },
         tech_stacks: { only: [:id, :technology, :version] },
-        tags: { only: [:id, :name] }
+        tags: { only: [:id, :name] },
       }
     end
 end

--- a/backend/app/controllers/api/portfolios_controller.rb
+++ b/backend/app/controllers/api/portfolios_controller.rb
@@ -1,33 +1,44 @@
 class Api::PortfoliosController < ApplicationController
   include UserFindable
 
-  def index
-    user = find_user
-    portfolios = user.portfolios.includes(:features, :pages, :images, :tech_stacks, :tags)
+  before_action :set_user
 
-    render json: portfolios, include: {
-      features: { only: [:id, :name] },
-      pages: { only: [:id, :name] },
-      images: { only: [:id, :url] },
-      tech_stacks: { only: [:id, :technology, :version] },
-      tags: { only: [:id, :name] },
-    }
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "User not found" }, status: :not_found
+  def index
+    portfolios = @user.portfolios.includes(:features, :pages, :images, :tech_stacks, :tags)
+
+    render json: portfolios, include: portfolio_includes
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "User not found" }, status: :not_found
   end
 
   def show
-    user = find_user
-    portfolio = user.portfolios.includes(:features, :pages, :images, :tech_stacks, :tags).find(params[:id])
+    portfolio = @user.portfolios.includes(:features, :pages, :images, :tech_stacks, :tags).find_by(id: params[:id])
 
-    render json: portfolio, include: {
-      features: { only: [:id, :name] },
-      pages: { only: [:id, :name] },
-      images: { only: [:id, :url] },
-      tech_stacks: { only: [:id, :technology, :version] },
-      tags: { only: [:id, :name] },
-    }
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "Portfolio not found" }, status: :not_found
+    if portfolio.nil?
+      render json: { error: "Portfolio not found" }, status: :not_found
+    else
+      render json: portfolio, include: portfolio_includes
+    end
+    
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "User not found" }, status: :not_found
   end
+
+  private
+
+    def set_user
+      @user = find_user
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "User not found" }, status: :not_found
+    end
+
+    def portfolio_includes
+      {
+        features: { only: [:id, :name] },
+        pages: { only: [:id, :name] },
+        images: { only: [:id, :url] },
+        tech_stacks: { only: [:id, :technology, :version] },
+        tags: { only: [:id, :name] }
+      }
+    end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
     get "profile", to: "profile#show"
     get "skills", to: "skills#index"
     get "portfolios", to: "portfolios#index"
+    get "portfolios/:id", to: "portfolios#show"
   end
 end

--- a/backend/spec/requests/api/portfolios_spec.rb
+++ b/backend/spec/requests/api/portfolios_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Api::PortfoliosController", type: :request do
         it "returns status 200 and the portfolio data" do
           get "/api/portfolios/#{portfolio.id}"
           expect(response).to have_http_status(:ok)
-          
+
           json_response = JSON.parse(response.body)
           expect(json_response["id"]).to eq(portfolio.id)
           expect(json_response["name"]).to eq(portfolio.name)

--- a/backend/spec/requests/api/portfolios_spec.rb
+++ b/backend/spec/requests/api/portfolios_spec.rb
@@ -72,4 +72,58 @@ RSpec.describe "Api::PortfoliosController", type: :request do
       end
     end
   end
+
+  describe "GET /api/portfolios/:id" do
+    context "when the user exists" do
+      let!(:user) {
+        User.find_or_create_by(email: "keita@example.com") do |user|
+          user.password = "password"
+        end
+      }
+      let!(:portfolio) { create(:portfolio, user: user) }
+      let!(:features) { create_list(:feature, 3, portfolio: portfolio) }
+      let!(:pages) { create_list(:page, 2, portfolio: portfolio) }
+      let!(:images) { create_list(:image, 2, portfolio: portfolio) }
+      let!(:tech_stacks) { create_list(:tech_stack, 2, portfolio: portfolio) }
+      let!(:tags) { create_list(:tag, 2) }
+      before do
+        portfolio.tags << tags
+        allow_any_instance_of(Api::PortfoliosController).to receive(:find_user).and_return(user)
+      end
+
+      context "and the portfolio exists" do
+        it "returns status 200 and the portfolio data" do
+          get "/api/portfolios/#{portfolio.id}"
+          expect(response).to have_http_status(:ok)
+          
+          json_response = JSON.parse(response.body)
+          expect(json_response["id"]).to eq(portfolio.id)
+          expect(json_response["name"]).to eq(portfolio.name)
+        end
+      end
+
+      context "but the portfolio does not exist" do
+        it "returns status 404 and an error message" do
+          nonexistent_portfolio_id = "9999"
+          get "/api/portfolios/#{nonexistent_portfolio_id}"
+          json_response = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:not_found)
+          expect(json_response["error"]).to eq("Portfolio not found")
+        end
+      end
+    end
+
+    context "when the user does not exist" do
+      before { allow_any_instance_of(UserFindable).to receive(:find_user).and_raise(ActiveRecord::RecordNotFound) }
+
+      it "returns status 404 and an error message" do
+        get "/api/portfolios/1"
+        json_response = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:not_found)
+        expect(json_response["error"]).to eq("User not found")
+      end
+    end
+  end
 end

--- a/frontend/src/components/utility/TagList.tsx
+++ b/frontend/src/components/utility/TagList.tsx
@@ -1,7 +1,7 @@
+import { Box } from '@mui/material'
 import { memo } from 'react'
 import { Tag } from './Tag'
 import { Tag as TagType } from '@/types/tag'
-import { Box } from '@mui/material'
 
 type TagListProps = {
   tags: TagType[]

--- a/frontend/src/components/utility/TagList.tsx
+++ b/frontend/src/components/utility/TagList.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 import { Tag } from './Tag'
 import { Tag as TagType } from '@/types/tag'
+import { Box } from '@mui/material'
 
 type TagListProps = {
   tags: TagType[]
@@ -10,10 +11,16 @@ type TagListProps = {
 export const TagList = memo(({ tags, maxTags }: TagListProps) => {
   const tagsToDisplay = maxTags ? tags.slice(0, maxTags) : tags
   return (
-    <>
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1,
+      }}
+    >
       {tagsToDisplay.map((tag, index) => (
         <Tag key={index} tag={tag} />
       ))}
-    </>
+    </Box>
   )
 })

--- a/frontend/src/data/portfolios.ts
+++ b/frontend/src/data/portfolios.ts
@@ -39,7 +39,7 @@ export const portfolios = [
         alt: 'Project 1 Image 4',
       },
     ],
-    techStack: [
+    techStacks: [
       { id: 1, technology: 'React', version: '17.0.2' },
       { id: 2, technology: 'Node.js', version: '14.17.0' },
       { id: 3, technology: 'Next.js', version: '10.0.0' },
@@ -85,7 +85,7 @@ export const portfolios = [
         alt: 'Project 2 Image 4',
       },
     ],
-    techStack: [
+    techStacks: [
       { id: 1, technology: 'Rails', version: '6.1.0' },
       { id: 2, technology: 'PostgreSQL', version: '13.3' },
       { id: 3, technology: 'Docker', version: '20.10.7' },
@@ -130,7 +130,7 @@ export const portfolios = [
         alt: 'Project 3 Image 4',
       },
     ],
-    techStack: [
+    techStacks: [
       { id: 1, technology: 'Vue.js', version: '3.0.0' },
       { id: 2, technology: 'CSS', version: '3.0' },
       { id: 3, technology: 'API', version: 'v2' },
@@ -176,7 +176,7 @@ export const portfolios = [
         alt: 'Project 4 Image 4',
       },
     ],
-    techStack: [
+    techStacks: [
       { id: 1, technology: 'Angular', version: '11.0.0' },
       { id: 2, technology: 'TypeScript', version: '4.2.3' },
       { id: 3, technology: 'Firebase', version: '9.0.0' },
@@ -222,7 +222,7 @@ export const portfolios = [
         alt: 'Project 5 Image 4',
       },
     ],
-    techStack: [
+    techStacks: [
       { id: 1, technology: 'Next.js', version: '10.1.0' },
       { id: 2, technology: 'GraphQL', version: '15.6.0' },
       { id: 3, technology: 'AWS', version: 'v3' },
@@ -267,7 +267,7 @@ export const portfolios = [
         alt: 'Project 6 Image 4',
       },
     ],
-    techStack: [
+    techStacks: [
       { id: 1, technology: 'Svelte', version: '3.38.0' },
       { id: 2, technology: 'API', version: 'v1' },
       { id: 3, technology: 'WebSocket', version: '1.0' },

--- a/frontend/src/features/common/components/DemoLink.tsx
+++ b/frontend/src/features/common/components/DemoLink.tsx
@@ -8,7 +8,7 @@ type DemoLinkProps = {
 
 export const DemoLink = ({ url }: DemoLinkProps) => {
   return (
-    <PortfolioLink href={url} color="primary" borderColor="primary">
+    <PortfolioLink href={url} color="#fff" backgroundColor="#2196f3">
       <LaunchIcon sx={{ marginRight: 1 }} />
       <Typography>デモ</Typography>
     </PortfolioLink>

--- a/frontend/src/features/portfolioDetail/components/ImageGallery.tsx
+++ b/frontend/src/features/portfolioDetail/components/ImageGallery.tsx
@@ -1,11 +1,11 @@
 import { Box, Grid } from '@mui/material'
 import Image from 'next/image'
-import { ImageItem } from '../types/imageItem'
 import { ImageGalleryItem } from './ImageGalleryItem'
+import { Image as ImageType } from '@/types/image'
 
 type ImageGalleryProps = {
   thumbnail: string
-  items: ImageItem[]
+  items: ImageType[]
   onClick: (imageUrl: string) => void
 }
 

--- a/frontend/src/features/portfolioDetail/components/ImageGalleryItem.tsx
+++ b/frontend/src/features/portfolioDetail/components/ImageGalleryItem.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image'
-import { ImageItem } from '../types/imageItem'
+import { Image as ImageType } from '@/types/image'
 
 type ImageItemProps = {
-  item: ImageItem
+  item: ImageType
   onClick: (imageUrl: string) => void
 }
 
@@ -10,7 +10,7 @@ export const ImageGalleryItem = ({ item, onClick }: ImageItemProps) => {
   return (
     <Image
       src={item.url}
-      alt={item.alt}
+      alt="ポートフォリオ画像"
       width={300}
       height={200}
       style={{ width: '100%', height: 'auto' }}

--- a/frontend/src/features/portfolioDetail/components/Section.tsx
+++ b/frontend/src/features/portfolioDetail/components/Section.tsx
@@ -1,0 +1,18 @@
+import { Box } from '@mui/material'
+import { ReactNode } from 'react'
+import { SectionTitle } from './SectionTitle'
+
+type SectionProps = {
+  title: string
+  marginTop?: number
+  children: ReactNode
+}
+
+export const Section = ({ title, marginTop = 6, children }: SectionProps) => {
+  return (
+    <Box sx={{ marginTop: marginTop }}>
+      <SectionTitle title={title} />
+      <Box sx={{ marginTop: 2 }}>{children}</Box>
+    </Box>
+  )
+}

--- a/frontend/src/features/portfolioDetail/components/SectionTitle.tsx
+++ b/frontend/src/features/portfolioDetail/components/SectionTitle.tsx
@@ -1,0 +1,13 @@
+import { Typography } from '@mui/material'
+
+type SectionTitleProps = {
+  title: string
+}
+
+export const SectionTitle = ({ title }: SectionTitleProps) => {
+  return (
+    <Typography variant="h5" sx={{ fontWeight: 'bold' }}>
+      {title}
+    </Typography>
+  )
+}

--- a/frontend/src/pages/portfolios/[id].tsx
+++ b/frontend/src/pages/portfolios/[id].tsx
@@ -41,7 +41,17 @@ const PortfolioDetail = ({ portfolio }: PortfolioDetailProps) => {
       <Section title="説明">
         <Typography>{portfolio.description}</Typography>
       </Section>
-      <Box sx={{ marginTop: 4, display: 'flex', gap: 2 }}>
+      <Box
+        sx={{
+          marginTop: 4,
+          display: 'flex',
+          gap: 2,
+          flexDirection: {
+            xs: 'column',
+            sm: 'row',
+          },
+        }}
+      >
         <DemoLink url={portfolio.demoUrl} />
         <GithubLink url={portfolio.githubUrl} />
         <BlogLink url={portfolio.blogUrl} />

--- a/frontend/src/pages/portfolios/[id].tsx
+++ b/frontend/src/pages/portfolios/[id].tsx
@@ -5,14 +5,14 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import { useState } from 'react'
 import { TextAlignLayout } from '@/components/layouts/common/TextAlignLayout'
 import { TagList } from '@/components/utility/TagList'
+import { BlogLink } from '@/features/common/components/BlogLink'
 import { DemoLink } from '@/features/common/components/DemoLink'
 import { GithubLink } from '@/features/common/components/GithubLink'
 import { ImageGallery } from '@/features/portfolioDetail/components/ImageGallery'
 import { List } from '@/features/portfolioDetail/components/List'
+import { Section } from '@/features/portfolioDetail/components/Section'
 import { StackTable } from '@/features/portfolioDetail/components/StackTable'
 import { Portfolio } from '@/types/portfolio'
-import { Section } from '@/features/portfolioDetail/components/Section'
-import { BlogLink } from '@/features/common/components/BlogLink'
 
 type PortfolioDetailProps = {
   portfolio: Portfolio
@@ -20,7 +20,7 @@ type PortfolioDetailProps = {
 
 const PortfolioDetail = ({ portfolio }: PortfolioDetailProps) => {
   const [selectedThumbnail, setSelectedThumbnail] = useState(
-    portfolio.thumbnail
+    portfolio.thumbnail,
   )
 
   const handleImageClick = (imageUrl: string) => {

--- a/frontend/src/pages/portfolios/[id].tsx
+++ b/frontend/src/pages/portfolios/[id].tsx
@@ -98,7 +98,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'https://backend:3000'
   const portfolioRes = await axios.get(`${backendUrl}/api/portfolios/${id}`)
-  const portfolio = camelcaseKeys(portfolioRes.data) as Portfolio[]
+  const portfolio = camelcaseKeys(portfolioRes.data) as Portfolio
 
   if (!portfolio) {
     return { notFound: true }


### PR DESCRIPTION
## 概要

ポートフォリオ詳細機能作成

## やったこと

- デモリンク、タグのスタイルの修正
- ポートフォリオ詳細機能作成
- SSGでAPIと通信してポートフォリオ詳細のデータを取得する
- ポートフォリオ詳細で使うセクションをコンポーネント化
- portfolios_controllerのindex、showをリファクタリング
- ポートフォリオ詳細のリクエストスペック作成

## 動作確認

https://keita-portfolio-gold.vercel.app/portfolios/1

API
https://keita-portfolio.onrender.com/api/portfolios/1

## 懸念点

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added individual portfolio retrieval endpoint.
	- Implemented portfolio detail page with dynamic data fetching.
	- Created new `Section` and `SectionTitle` components for improved portfolio detail layout.

- **Bug Fixes**
	- Updated data model references for image and tech stack properties.

- **Refactor**
	- Enhanced error handling in backend portfolio controller.
	- Improved frontend portfolio detail page structure.
	- Updated routing for portfolio detail retrieval.

- **Style**
	- Modified `DemoLink` component styling.
	- Refined portfolio detail page layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->