### PR TITLE
railsのデプロイ後にnext.jsをデプロイする

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
           timeout: 300
 
   deploy-next:
-    needs: [ci]
+    needs: [deploy-rails]
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
## 概要

railsのデプロイ後にnext.jsをデプロイする

## やったこと

CDでrailsのデプロイ後にnext.jsをデプロイするように修正

## 動作確認

## 懸念点

## その他
